### PR TITLE
msgpack-python is now maintained as msgpack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-UUID>=0.2
 sentry-sdk[flask]>=0.20.2
 certifi
 redis>=3.5,<4.0
-msgpack-python==0.5.6
+msgpack==0.5.6
 requests>=2.23.0
 SQLAlchemy>=1.3.16
 mbdata==25.0.4


### PR DESCRIPTION
The package has been renamed to msgpack so use the newer name. See https://pypi.org/project/msgpack/ and https://github.com/msgpack/msgpack-python/issues/109.